### PR TITLE
feat: validate d-number

### DIFF
--- a/lib/no_ssn_validator.js
+++ b/lib/no_ssn_validator.js
@@ -13,7 +13,12 @@
         return false;
       }
 
-      if (!exports.isDateValid(number.substring(0, 6))) {
+      var date = number.substring(0, 6);
+      if (exports.isDNumber(number)) {
+        date = (parseInt(date.substring(0, 1), 10) - 4).toString() + date.substring(1, 6);
+      }
+
+      if (!exports.isDateValid(date)) {
         return false;
       }
 
@@ -42,6 +47,15 @@
       }
 
       return true;
+    };
+
+    exports.isDNumber = function (date) {
+      var day = parseInt(date.substring(0, 2));
+
+      if (day > 40 && day < 72) {
+        return true;
+      }
+      return false;
     };
 
     exports.getGender = function (number) {

--- a/test/no_ssn_validator_test.js
+++ b/test/no_ssn_validator_test.js
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import sinon from 'sinon'
 
 var noSSNValidator = require("../lib/no_ssn_validator"),
-{isDateValid, isValid, getGender, Gender, calculateFirstChecksum, calculateSecondChecksum} = noSSNValidator
+{isDateValid, isDNumber, isValid, getGender, Gender, calculateFirstChecksum, calculateSecondChecksum} = noSSNValidator
 
 describe("noSSNValidator", () => {
   var sandbox;
@@ -75,6 +75,14 @@ describe("noSSNValidator", () => {
 
       expect(isValid("11021599915")).to.equal(true);
     });
+
+    it("should return true for a correct d-number", () => {
+      sandbox.stub(noSSNValidator, "isDateValid").returns(true);
+      sandbox.stub(noSSNValidator, "calculateFirstChecksum").returns("5");
+      sandbox.stub(noSSNValidator, "calculateSecondChecksum").returns("9");
+
+      expect(isValid("45118036559")).to.equal(true);
+    });
   });
 
   describe("getGender", () => {
@@ -91,6 +99,20 @@ describe("noSSNValidator", () => {
     it("should return false for invalid number", () => {
       sandbox.stub(noSSNValidator, "isValid").returns(false);
       expect(getGender("01234567890")).to.equal(false);
+    });
+  });
+
+  describe("isDNumber", () => {
+    it("should return false if the offset is below 41", () => {
+      expect(isDNumber("201185")).to.equal(false);
+    });
+
+    it("should return false if the offset it higher than 71", () => {
+      expect(isDNumber("721185")).to.equal(false);
+    });
+
+    it("should return true for a valid day with 40 in offset", () => {
+      expect(isDNumber("411185")).to.equal(true);
     });
   });
 


### PR DESCRIPTION
Added validation of d-number that is a temporally ssn. In general
is follow the same rules as the normal ssn validation but has a offset
of 40 on the day of birth. The calculation of control number should use
the day with the offset.
